### PR TITLE
Introduce Channel.transfer

### DIFF
--- a/federated_aggregations/paillier/strategy.py
+++ b/federated_aggregations/paillier/strategy.py
@@ -123,10 +123,9 @@ class PaillierStrategy(federating_executor.CentralizedIntrinsicStrategy):
                       pl, pl_cardinality))
   
   async def _move(self, value, source_placement, target_placement):
-    await self.channel_grid.setup_channels(self)
+    await asyncio.gather(self.channel_grid.setup_channels(self))
     channel = self.channel_grid[(source_placement, target_placement)]
-    sent = await channel.send(value)
-    return await channel.receive(sent)
+    return await channel.transfer(value)
 
   async def _paillier_setup(self):
     # Load paillier keys on server


### PR DESCRIPTION
Introduce the `Channel.transfer` method, which further loosens coupling between Strategy and Channel.

New Channel classes should now inherit from `BaseChannel`, whose responsibility is to implement & manage the contract between Strategy and Channel. It requires that all subclasses implement their own version of `send` and `receive` in order to fulfill their end of the contract. These methods now correspond to pre-processing and post-processing of any value that's meant to be transferred between the two placements. The transfer itself, i.e. conversion from `FederatedType(value, sender)` to `FederatedType(value, receiver)`, is taken care of by `transfer`. Thus, Channels should avoid calling `value.compute()` for any value passing through `send` and `receive` to avoid any unintentional communication or marshaling of data.

This PR also rearranges the order of certain methods, to improve readability.